### PR TITLE
Fix additional "ignored" entry in the routing rules example.

### DIFF
--- a/src/fnerouter/routing_rules.example.yml
+++ b/src/fnerouter/routing_rules.example.yml
@@ -30,8 +30,7 @@
         #
         routable: false
         # Flag indicating which hosts to ignore traffic from. If blank use [].
-        ignored:
-            - 0
+        ignored: []
       #
       # Source Configuration
       #


### PR DESCRIPTION
Missed a line when correcting prior.